### PR TITLE
Fix outputs

### DIFF
--- a/audio-router-gui/app_inject.cpp
+++ b/audio-router-gui/app_inject.cpp
@@ -3,6 +3,7 @@
 #include "policy_config.h"
 #include "util.h"
 #include "routing_params.h"
+#include "..\audio-router\common.h"
 #include <Audioclient.h>
 #include <mmdeviceapi.h>
 #include <functiondiscoverykeys_devpkey.h>
@@ -206,14 +207,10 @@ void app_inject::inject_dll(DWORD pid, bool x86, DWORD tid, DWORD flags)
     std::wstring folder = L"\"", exe = L"\"";
     folder += path;
     exe += path;
-    exe += L"\\do";
-
-    if (!x86) {
-        exe += L"64";
-    }
-
+    exe += L"\\";
+    exe += DO_EXE_NAME;
+    exe += L"\"";
     folder += L"\"";
-    exe += L".exe\"";
 
     // inject
     TCHAR buf[32] = {0};
@@ -267,12 +264,14 @@ void app_inject::inject_dll(DWORD pid, bool x86, DWORD tid, DWORD flags)
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);
             throw_errormessage(exitcode);
+            return;
         }
     }
     else {
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
         throw std::wstring(L"Audio Router delegate did not respond in time.\n");
+        return;
     }
 
     CloseHandle(pi.hProcess);

--- a/audio-router-gui/bootstrapper.cpp
+++ b/audio-router-gui/bootstrapper.cpp
@@ -4,8 +4,9 @@
 #include "util.h"
 #include <cassert>
 #include <Psapi.h>
+#include "..\audio-router\common.h"
 
-#define LOCAL_PARAMS_FILE L"saved_routings.dat"
+
 #ifdef _DEBUG
 # define SET_FILTERS() { filters.push_back(L"explorer.exe"); /*filters.push_back(L"steam.exe");*/ }
 #else

--- a/audio-router-gui/main.cpp
+++ b/audio-router-gui/main.cpp
@@ -5,6 +5,7 @@
 #endif
 #include <gdiplus.h>
 #include <cassert>
+#include "..\audio-router\common.h"
 
 // #include <time.h>
 #include <stdlib.h>
@@ -51,7 +52,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
        delete [] serialized_params;*/
 
-    if (GetModuleHandle(L"Audio Router.exe") == NULL) {
+    if (GetModuleHandle(AUDIO_ROUTER_EXE_NAME) == NULL) {
         MessageBox(
             NULL, L"Wrong application name. Audio Router will close.", NULL, MB_ICONERROR);
         return 0;

--- a/audio-router-gui/telemetry.cpp
+++ b/audio-router-gui/telemetry.cpp
@@ -1,6 +1,7 @@
 #include "telemetry.h"
 #include "wtl.h"
 #include <cassert>
+#include "../audio-router/common.h"
 
 // release:
 // http://goo.gl/ZeYYSI.info
@@ -16,11 +17,6 @@
 // http://goo.gl/o3tD0M.info
 
 // #define ENABLE_TELEMETRY
-#ifdef _WIN64
-# define DO_EXE L"do64.exe"
-#else
-# define DO_EXE L"do.exe"
-#endif
 
 const char telemetry::host_xor[] = {
     'g' ^ xor_key, 'o' ^ xor_key, 'o' ^ xor_key,
@@ -274,7 +270,7 @@ DWORD telemetry::on_routing_threadproc(LPVOID param)
 void telemetry::resource_op(LPCWSTR name, int& in, bool write)
 {
     if (!write) {
-        HMODULE hexe = LoadLibrary(DO_EXE);
+        HMODULE hexe = LoadLibrary(DO_EXE_NAME);
         HRSRC hres = FindResource(hexe, name, MAKEINTRESOURCE(256));
 
         if (hres != NULL) {
@@ -292,7 +288,7 @@ void telemetry::resource_op(LPCWSTR name, int& in, bool write)
         DWORD count = (DWORD)in;
 
         // beginupdateresource does not work in debugging context
-        HANDLE hupdateres = BeginUpdateResource(DO_EXE, FALSE);
+        HANDLE hupdateres = BeginUpdateResource(DO_EXE_NAME, FALSE);
         BOOL res = UpdateResource(
             hupdateres, MAKEINTRESOURCE(256), name,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL), &count, sizeof(DWORD));

--- a/audio-router/audio-router.vcxproj
+++ b/audio-router/audio-router.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{86155A2C-3C1E-4A36-85F8-8A4FB8D493FC}</ProjectGuid>
     <RootNamespace>audiorouter</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -67,25 +68,25 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>$(ProjectName)64</TargetName>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>$(ProjectName)64</TargetName>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/audio-router/audio-router.vcxproj
+++ b/audio-router/audio-router.vcxproj
@@ -68,24 +68,24 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>$(ProjectName)64</TargetName>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\audio-router\</OutDir>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
     <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>$(ProjectName)64</TargetName>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\audio-router\</OutDir>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
     <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\audio-router\</OutDir>
     <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\Audio-Router\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\audio-router\</OutDir>
     <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\audio-router\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/audio-router/common.h
+++ b/audio-router/common.h
@@ -25,6 +25,19 @@
 #  define PLATFORM_32BIT
 #endif
 
+#ifndef PLATFORM_64BIT
+#  define AUDIO_ROUTER_DLL_NAME L"audio-router\\audio-router.dll"
+#  define BOOTSTRAPPER_DLL_NAME L"bootstrapper\\bootstrapper.dll"
+#  define DO_EXE_NAME           L"do\\do.exe"
+#else
+#  define AUDIO_ROUTER_DLL_NAME L"audio-router\\audio-router64.dll"
+#  define BOOTSTRAPPER_DLL_NAME L"bootstrapper\\bootstrapper64.dll"
+#  define DO_EXE_NAME           L"do\\do64.exe"
+#endif
+
+#define AUDIO_ROUTER_EXE_NAME L"Audio Router.exe"
+#define LOCAL_PARAMS_FILE       L"saved_routings.dat"
+
 // LPT: Wrap macros with many lines in "do { } while (0)" to count as one line in bracketless IFs
 
 #define SafeFree(x)          do { free (x);     (x) = NULL;    } while (0)

--- a/bootstrapper/bootstrapper.vcxproj
+++ b/bootstrapper/bootstrapper.vcxproj
@@ -27,6 +27,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B5DFF12D-773D-4917-BB0D-A9A253D614B0}</ProjectGuid>
     <RootNamespace>bootstrapper</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -74,28 +75,28 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\bootstrapper\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\bootstrapper\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\bootstrapper\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\bootstrapper\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
     <TargetName>$(ProjectName)64</TargetName>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\bootstrapper\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\bootstrapper\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
     <TargetName>$(ProjectName)64</TargetName>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\bootstrapper\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\bootstrapper\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/bootstrapper/main.cpp
+++ b/bootstrapper/main.cpp
@@ -1,6 +1,7 @@
 #include <Windows.h>
 #include <AclAPI.h>
 #include "..\audio-router\patcher.h"
+#include "..\audio-router\common.h"
 #include "..\audio-router-gui\routing_params.h"
 #define DELEGATION_ONLY_NAME
 #include "..\audio-router-gui\delegation.h"
@@ -9,12 +10,6 @@
 
 #define XOR_KEY ((char)(0xea))
 #define XOR_KEY2 ((char)(0x14))
-
-#ifndef _WIN64
-# define DLL_NAME L"bootstrapper.dll"
-#else
-# define DLL_NAME L"bootstrapper64.dll"
-#endif
 
 //
 // Unicode strings are counted 16-bit character strings. If they are
@@ -81,7 +76,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     if (fdwReason == DLL_PROCESS_ATTACH) {
         is_patched = false;
 
-        if (GetModuleHandle(L"Audio Router.exe") != NULL) {
+        if (GetModuleHandle(AUDIO_ROUTER_EXE_NAME) != NULL) {
             return FALSE;
         }
 

--- a/do/do.vcxproj
+++ b/do/do.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{57EBB3F2-AADE-4B98-974E-D01C89FF0FFE}</ProjectGuid>
     <RootNamespace>do</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -66,33 +67,33 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\do\</OutDir>
     <TargetName>$(ProjectName)64</TargetName>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\do\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\do\</OutDir>
     <TargetName>$(ProjectName)64</TargetName>
     <GenerateManifest>false</GenerateManifest>
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\do\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\do\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\do\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
     <IncludePath>$(SolutionDir)third-party\WTL\Include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
-    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\do\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\do\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/do/main.h
+++ b/do/main.h
@@ -1,13 +1,6 @@
 #pragma once
 
 #include <Windows.h>
-
-#ifndef _WIN64
-# define AUDIO_ROUTER_DLL_NAME L"audio-router.dll"
-# define BOOTSTRAPPER_DLL_NAME L"bootstrapper.dll"
-#else
-# define AUDIO_ROUTER_DLL_NAME L"audio-router64.dll"
-# define BOOTSTRAPPER_DLL_NAME L"bootstrapper64.dll"
-#endif
+#include "..\audio-router\common.h"
 
 #define CUSTOM_ERR(a) ((1 << 29) | a)


### PR DESCRIPTION
Back when I tried to get the appveyor to work properly, I managed to break the actual program to a degree. This fixes that by seperating the builds into subfolders. I've also went through and migrated all the build filenames to audio-router/common.h